### PR TITLE
fix(serial-port): move DispatchQueueThread to module, update SerialControl, and integrate in sample MainActivity

### DIFF
--- a/serial-port/src/main/java/com/mascill/serialport/access/SerialControl.kt
+++ b/serial-port/src/main/java/com/mascill/serialport/access/SerialControl.kt
@@ -1,0 +1,24 @@
+package com.mascill.serialport.access
+
+import com.mascill.serialport.helper.SerialHelper
+import com.mascill.serialport.helper.thread.DispatchQueueThread
+
+class SerialControl : SerialHelper {
+
+    private var dispatchQueue: DispatchQueueThread? = null
+
+    constructor() : super()
+
+    constructor(sPort: String, dispatchQueue: DispatchQueueThread) : super(sPort) {
+        this.dispatchQueue = dispatchQueue
+    }
+
+    constructor(sPort: String) : super(sPort)
+
+    override fun onDataReceived(comRecData: ByteArray) {
+        dispatchQueue?.apply {
+            addQueue(comRecData)
+            setResume()
+        }
+    }
+}

--- a/serial-port/src/main/java/com/mascill/serialport/access/SerialModuleAccess.kt
+++ b/serial-port/src/main/java/com/mascill/serialport/access/SerialModuleAccess.kt
@@ -1,0 +1,106 @@
+package com.mascill.serialport.access
+
+import com.mascill.serialport.constant.SerialAccess
+import com.mascill.serialport.helper.SerialHelper
+import com.mascill.serialport.helper.ShellUtils.execCommand
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+
+class SerialModuleAccess {
+
+    fun connect(
+        serialControl: SerialHelper,
+        portName: String,
+        baudRate: Int,
+        result: (Boolean, String) -> Unit
+    ) {
+        try {
+            val port = "/dev/$portName"
+            serialControl.setPort(port)
+            serialControl.setBaudRate(baudRate)
+            serialControl.setParity(0)
+            serialControl.open()
+            result(true, "Connected") // isConnected
+        } catch (e: Exception) {
+            val errorMessage = "Connection failed: ${e.toString()}"
+            result(false, errorMessage)
+        }
+    }
+
+    // sendData
+    fun sendDataSerial(
+        serialControl: SerialHelper,
+        data: String,
+        result: (Boolean, String) -> Unit
+    ) {
+        try {
+            val t: CharSequence = data
+            val text = CharArray(t.length)
+            for (i in 0..<t.length) {
+                text[i] = t[i]
+            }
+            sendPortData(serialControl, text)
+            result(true, "SendData Successfully")
+        } catch (e: Exception) {
+            val errorMessage = "SendData Failed  ${e.message}"
+            result(false, errorMessage)
+        }
+    }
+
+    private fun sendPortData(comPort: SerialHelper?, sOut: CharArray) {
+        if (comPort != null && comPort.isOpen) {
+            comPort.sendData(sOut, true)
+        } else {
+            throw Exception("Port tidak tersedia atau belum terbuka")
+        }
+    }
+
+    // getListPort
+    fun getListPort(): MutableList<String?> {
+        val commandResult = execCommand(SerialAccess.LIST_PORT_COMMAND_EXEC, false)
+        val pattern: Pattern = Pattern.compile(SerialAccess.LIST_PORT_PATTERN)
+        val detectedPorts: MutableList<String?> = ArrayList()
+
+        if (commandResult.result == 0) {
+            val commandOutput = commandResult.successMsg
+            if (commandOutput == null) {
+                return mutableListOf("unknown")
+            }
+
+            val matcher: Matcher = pattern.matcher(commandOutput)
+
+            while (matcher.find()) {
+                val ttyDeviceName = matcher.group(1)
+                detectedPorts.add(ttyDeviceName)
+            }
+        }
+
+        return if (detectedPorts.isEmpty()) mutableListOf("unknown") else detectedPorts
+    }
+
+    fun getSerialDeviceTtyUSB(): String {
+        val result = execCommand(SerialAccess.LIST_TTY_COMMAND, false)
+        if (result.result != 0 || result.successMsg == null) {
+            return "unknown"
+        }
+
+        val lines =
+            result.successMsg!!.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val ttyUSBPattern = Pattern.compile(SerialAccess.TTY_USB_PATTERN)
+
+        for (line in lines) {
+            if (!line.contains(SerialAccess.USB_DEVICE_PATH)) {
+                continue
+            }
+
+            val matcher = ttyUSBPattern.matcher(line)
+            if (matcher.find()) {
+                return matcher.group()
+            }
+        }
+
+        return "unknown"
+    }
+}
+

--- a/serial-port/src/main/java/com/mascill/serialport/constant/SerialAccess.kt
+++ b/serial-port/src/main/java/com/mascill/serialport/constant/SerialAccess.kt
@@ -1,0 +1,10 @@
+package com.mascill.serialport.constant
+
+object SerialAccess {
+   const val USB_DEVICE_PATH =
+        "devices/platform/soc/4e00000.ssusb/4e00000.dwc3/xhci-hcd.2.auto/usb1/1-1/1-1.5/1-1.5:1.0"
+    const val LIST_TTY_COMMAND = "ls -la /sys/class/tty/"
+    const val TTY_USB_PATTERN = "ttyUSB(\\d+)"
+    const val LIST_PORT_COMMAND_EXEC = "ls -l /sys/class/tty/tty*"
+    const val LIST_PORT_PATTERN = "/sys/class/tty/(\\w+) -> .*?/tty/(\\w+)"
+}

--- a/serial-port/src/main/java/com/mascill/serialport/helper/thread/DispatchQueueThread.kt
+++ b/serial-port/src/main/java/com/mascill/serialport/helper/thread/DispatchQueueThread.kt
@@ -1,7 +1,8 @@
-package com.mascill.serialport.sample
+package com.mascill.serialport.helper.thread
 
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
+import java.lang.Object
 
 /**
  * Thread antrian display yang independen dari Activity.
@@ -10,10 +11,10 @@ import java.util.concurrent.LinkedBlockingQueue
  * @param onData callback untuk setiap paket yang di-pop dari antrian
  * @param perItemSleepMs jeda kecil antar item (default 5ms) agar UI tidak janky
  */
-class DispQueueThread(
+class DispatchQueueThread(
     private val onData: (ByteArray) -> Unit,
     private val perItemSleepMs: Long = 5L
-) : Thread("DispQueue") {
+) : Thread("DispatchQueue") {
 
     private val queueList: BlockingQueue<ByteArray> = LinkedBlockingQueue()
     @Volatile private var running: Boolean = true


### PR DESCRIPTION
### Summary  
This PR consolidates the threading helper into the `serial-port` module, updates `SerialControl` to handle queued data properly, and integrates these changes into the sample app’s `MainActivity`.

### Changes  
- Renamed `DispQueueThread` → `DispatchQueueThread` for consistency  
- Moved `DispatchQueueThread` implementation from sample app into the **serial-port** module  
- Updated `SerialControl` to accept a `DispatchQueueThread` instance and forward incoming serial data through the queue  
- Introduced `SerialModuleAccess` helper for connect/send/list operations  
- Added `SerialAccess` constants to centralize command strings and regex patterns  
- Updated `MainActivity` in the sample app:  
  - Integrated `DispatchQueueThread` lifecycle (start/stop, `ensureDispatchQueue`)  
  - Switched connection flow to use new `SerialControl` constructor with queue  
  - Improved UI state management for port/baud selection, data sending, and serial connection handling  

### Notes  
This fix improves modularity by moving queue/thread logic into the library instead of duplicating it in the sample app.  
It also ensures serial data is processed off the UI thread while keeping UI updates responsive via `Handler`.  
